### PR TITLE
Add Resiliparse Extractor

### DIFF
--- a/src/datatrove/pipeline/extractors/resiliparse.py
+++ b/src/datatrove/pipeline/extractors/resiliparse.py
@@ -1,0 +1,66 @@
+from .base import BaseExtractor
+
+
+class Resiliparse(BaseExtractor):
+    """Resiliparse extractor, it uses https://github.com/chatnoir-eu/chatnoir-resiliparse.
+
+    Args:
+        preserve_formatting: Preserve basic block-level formatting.
+        main_content: Apply simple heuristics for extracting only "main-content" elements.
+        list_bullets: Insert bullets or numbers for list items.
+        alt_texts: Preserve alternative text descriptions.
+        links: Extract link target URLs.
+        form_fields: Extract form fields and their values.
+        noscript: Extract contents of <noscript> elements.
+        comments: Treat comment sections as main content.
+    """
+
+    name = "⛏ Resiliparse"
+    _requires_dependencies = ["resiliparse"]
+
+    def __init__(
+        self,
+        main_content: bool = True, 
+        preserve_formatting: bool = True, 
+        list_bullets: bool = False,
+        alt_texts: bool = False, 
+        links: bool = False,
+        form_fields: bool = False,
+        noscript: bool = False,
+        comments: bool = False,
+        timeout: float = 0.1,
+        **kwargs,
+    ):
+        super().__init__(timeout)
+        self.main_content = main_content 
+        self.preserve_formatting = preserve_formatting
+        self.list_bullets = list_bullets
+        self.alt_texts = alt_texts
+        self.links = links
+        self.form_fields = form_fields
+        self.noscript = noscript
+        self.comments = comments
+        self.kwargs = kwargs
+
+    def extract(self, text: str) -> str:
+        """
+
+        Args:
+          text: str: html content
+
+        Returns: plain text extracted text
+
+        """
+        from resiliparse.extract.html2text import extract_plain_text
+
+        return extract_plain_text(
+            text,
+            main_content=self.main_content, 
+            preserve_formatting=self.preserve_formatting, 
+            list_bullets=self.list_bullets,
+            alt_texts=self.alt_texts,
+            links=self.links,
+            form_fields=self.form_fields,
+            noscript=self.noscript, 
+            comments=self.comments,
+        )


### PR DESCRIPTION
resiliparse extractor 추가.

dclm에서 사용하였으며, fineweb이 사용한 'trafilatura' 보다 훨씬 빠름. 

dclm이 진행한 filtering / dedup 방식을 datatrove를 활용하여 모방해보는 것이 1차 목표.
하지만 dclm에서 resiliparse를 쓸 때 구체적으로 어떤 방식으로 (어떤 arguments로) text extraction을 했는지 통 찾을 수가 없는 것이 큰 문제...

